### PR TITLE
Add opencontainer spec labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM	ghcr.io/voxelbonecloud/debian-dotnet:main	
 
 LABEL	author="Voxel Bone Cloud" maintainer="github@voxelbone.cloud"
+LABEL org.opencontainers.image.source=https://github.com/voxelbonecloud/headless-docker
+LABEL org.opencontainers.image.description="Docker image based on Debian Bookworm Slim image with dotnet8 for hosting Resonite Headless servers. Supports automatic modding of the Headless."
+LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.authors="Voxel Bone Cloud"
 
 RUN	apt update \
 	&& dpkg --add-architecture i386 \


### PR DESCRIPTION
Please delay the review or merge of this PR for when the dotnet8 build goes full release so only one image update is needed.

This Pr just adds the opencontainer spec labels to the dockerfile, these labels show in the github package area and certain software
Follows https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

