### PR TITLE
Update prometheus mod to use latest URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ volumes:
 
 The environment variables supported by this can be found in [example.env](example.env). Otherwise, they can be found below:
 
-Required variables
+Required variables - These are all that are required for a headless server
 ```
 STEAM_USER="YourSteamUsername"
 STEAM_PASS="YourSteamPassword"

--- a/scripts/update-resonite.sh
+++ b/scripts/update-resonite.sh
@@ -58,7 +58,7 @@ if [ "${ENABLE_AUTO_MOD_UPDATE}" = "true" ]; then
   # Headless Prometheus Exporter
   if [ "${MOD_PrometheusExporter}" = "true" ]; then
     echo "Installing Headless Prometheus Exporter"
-    curl -SslL  https://i.j4.lc/resonite/mods/latest/HeadlessPrometheusExporter.dll -o ${HEADLESS_DIRECTORY}/rml_mods/HeadlessPrometheusExporter.dll
+    curl -SslL https://i.j4.lc/resonite/mods/latest/HeadlessPrometheusExporter.dll -o ${HEADLESS_DIRECTORY}/rml_mods/HeadlessPrometheusExporter.dll
   fi
 
 fi

--- a/scripts/update-resonite.sh
+++ b/scripts/update-resonite.sh
@@ -58,7 +58,7 @@ if [ "${ENABLE_AUTO_MOD_UPDATE}" = "true" ]; then
   # Headless Prometheus Exporter
   if [ "${MOD_PrometheusExporter}" = "true" ]; then
     echo "Installing Headless Prometheus Exporter"
-    curl -SslL  https://i.j4.lc/ShareX/2024/09/HeadlessPrometheusExporter.dll -o ${HEADLESS_DIRECTORY}/rml_mods/HeadlessPrometheusExporter.dll
+    curl -SslL  https://i.j4.lc/resonite/mods/latest/HeadlessPrometheusExporter.dll -o ${HEADLESS_DIRECTORY}/rml_mods/HeadlessPrometheusExporter.dll
   fi
 
 fi


### PR DESCRIPTION
This changes the mod link for the Prometheus exporter to use the latest tagged link.
Also added some extra text on the required variables in the read me to stress you don't need the rest for a basic headless.