### PR TITLE
docker: move to Microsoft supplied dotnet image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM	ghcr.io/voxelbonecloud/debian-dotnet:main	
+FROM	mcr.microsoft.com/dotnet/runtime:8.0-bookworm-slim
 
 LABEL	author="Voxel Bone Cloud" maintainer="github@voxelbone.cloud"
 LABEL org.opencontainers.image.source=https://github.com/voxelbonecloud/headless-docker
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.authors="Voxel Bone Cloud"
 RUN	apt update \
 	&& dpkg --add-architecture i386 \
 	&& apt install curl git lib32gcc-s1 libfreetype6 -y \
-	&& useradd -m -d /home/container -s /bin/bash container
+	&& groupadd -g 1000 container \
+	&& useradd -u 1000 -g 1000 -m -d /home/container -s /bin/bash container
 
 COPY	./scripts /scripts
 


### PR DESCRIPTION
This moves us to the dotnet Docker images Microsoft provides.

As a result, we no longer have to maintain our own dotnet base image.