### PR TITLE
dotnet: update to .NET 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM	mcr.microsoft.com/dotnet/runtime:8.0-bookworm-slim
+FROM	mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim
 
 LABEL	author="Voxel Bone Cloud" maintainer="github@voxelbone.cloud"
 LABEL org.opencontainers.image.source=https://github.com/voxelbonecloud/headless-docker


### PR DESCRIPTION
Resonite's headless has updated to .NET 9, so we need to update